### PR TITLE
Default python prefix from sys.prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 MANDIR=/usr/share/man
 
 ifndef PREFIX
-  PREFIX=/usr
+  PREFIX=$(shell python -c "import sys; print(sys.prefix)")
 endif
 
 install: bash_completion


### PR DESCRIPTION
With this change, the default installation prefix is taken from the sys module.

This is consistent with how the variable PYTHON_SITELIB is defined.

Without this change, on a system using /usr/local as install prefix, the setup.py script will use /usr and the chmod command will use /usr/local, resulting in an error. 