### PR TITLE
Rikkotec Github.com and pcsd Makefile Patch For GNU/Linux

### DIFF
--- a/README
+++ b/README
@@ -33,4 +33,7 @@ You can also install pcsd which operates as a GUI and remote server for pcs.  To
 # cd pcsd ; make get_gems ; cd ..
 # make install_pcsd
 
+If you are using GNU/Linux its now time to:
+# systemctl daemon-reload
+
 If you have an questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+## PCS - Pacemaker/Corosync configuration system
+
+
+### Quick Start
+***
+
+
+- **PCS Installation from Source**
+
+   Run the following in terminal:
+  
+   ```shell
+   # tar -xzvf pcs-0.9.138.tar.gz
+   # cd pcs-0.9.138
+   # make install
+   ```
+
+   This will install pcs into `/usr/sbin/pcs`.
+
+<br />
+- **Create and Start a Basic Cluster**
+
+   To create a cluster run the following commands on all nodes (replacing node1, node2, node3 with a list of nodes in the cluster).
+
+   ```shell
+   # pcs cluster setup --local --name cluster_name node1 node2 node3
+   ```
+
+   Then run the following command on all nodes:
+
+   ```shell
+   # pcs cluster start
+   ```
+
+<br />
+- **Check the Cluster Status**
+
+   After a few moments the cluster should startup and you can get the status of the cluster
+
+   ```shell
+   # pcs status
+   ```
+
+<br />
+- **Add a Cluster Reosurce**
+
+   After this you can add resources and stonith agents:
+
+   ```shell
+   # pcs resource help
+   ```
+
+   and
+
+   ```shell
+   # pcs stonith help
+   ```
+
+   Currently this is built into Fedora (other distributions to follow).  You can see the current Fedora .spec in the fedora package git repositories here: http://pkgs.fedoraproject.org/cgit/pcs.git/
+
+   Current Fedora 18 .spec:   
+   http://pkgs.fedoraproject.org/cgit/pcs.git/tree/pcs.spec?h=f18
+
+<br />
+- **PCSD Installation from Source**
+
+   You can also install pcsd which operates as a GUI and remote server for pcs. pcsd may also necessary in order to follow the guides on the clusterlabs.org website.
+
+   To install pcsd run the following commands from the root of your pcs directory. (You must have the ruby bundler gem installed, rubygem-bundler in Fedora, and development packages installed)
+
+   ```shell
+   # cd pcsd ; make get_gems ; cd ..
+   # make install_pcsd
+   ```
+
+   If you are on GNU/Linux its time to:
+
+   ```shell
+   # systemctl daemon-reload
+   ```
+
+<br />
+### Inquiries
+***
+
+If you have any questions or concerns please feel free to email cfeist@redhat.com or open a github issue on the pcs project.

--- a/pcsd/Makefile
+++ b/pcsd/Makefile
@@ -1,9 +1,25 @@
+# This doesn't work for GNU/Linux.
 REL_INFO := $(shell grep -q -i "release 6" /etc/redhat-release ; echo $$?)
 
-ifeq (${REL_INFO},1)
-  build_gems: build_gems_normal
+# To support GNU/Linux, specifically Debian     
+UNAME_OS_GNU := $(shell if uname -o | grep -q "GNU/Linux" ; then echo 0; else echo 1; fi)
+UNAME_KERNEL_DEBIAN := $(shell if uname -v | grep -q "Debian" ; then echo 0; else echo 1; fi)
+UNAME_DEBIAN_VER_8 := $(shell if grep -q -i "8" /etc/debian_version ; then echo 0; else echo 1; fi)
+
+ifeq (${UNAME_OS_GNU},0)    
+  ifeq (${UNAME_KERNEL_DEBIAN},0)
+    ifeq (${UNAME_DEBIAN_VER_8},0)
+      build_gems: build_gems_normal
+    else
+      build_gems: build_gems_normal
+    endif
+  endif
 else
-  build_gems: build_gems_rhel6
+  ifeq (${REL_INFO},1)
+    build_gems: build_gems_normal
+  else
+    build_gems: build_gems_rhel6
+  endif
 endif
 
 build_gems_normal:


### PR DESCRIPTION
**Source Updates**
- Provided support for building pcsd on GNU/Linux, specifically Debian.  See `pcsd/Makefile`
- Added `README.md` to the source, which Github favors over README - and which presents a prettier and more readable documentation via the Github.com web project interface with updated documentation for GNU/Linux users in the pcsd installation steps.
- Updated `README` file to include additional information for GNU/Linux users in the pcsd installation steps.

**Additional Notes**
- Tested on Debian Jessie, with Pacemaker 1.11 and Corosync 2.x from experimental.
- I did not use sudo for `make get_gems` in the pcsd directory, this worked fine as non-root.
- I had to run `sudo make install`, and `sudo make install_pcsd` in order  to get privileges to create directories and copy files.
- I had to run `sudo systemctl daemon-reload` before I could utilize pcsd via `systemctl start pcsd.service`
- A warning is displayed when you `sudo make install_pcsd` from ruby, explaining not to install gems as the
  root user...this was unavoidable for me - but I'm new to Ruby, perhaps there is a way to avoid that.
- Using `sudo` should not be too much of a problem on Debian, as you can only use Pacemaker and
  Corosync as root anyhow.  File permission changes would be necessary through the whole cluster stack.
- I left an additional `else` in the `ifeq` blocks of `pcsd/Makefile` for Debian, in order to provide others a sort of *place-holder* for helping them to support additional Debian versions, since I didn't do any extensive testing.