### PR TITLE
setup.py: drop long-removed files from package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='pcs',
     author_email='cfeist@redhat.com',
     url='http://github.com/feist/pcs',
     packages=['pcs'],
-    package_data={'pcs':['corosync.conf.template','corosync.conf.fedora.template','bash_completion.d.pcs','pcs.8']}, 
+    package_data={'pcs':['bash_completion.d.pcs','pcs.8']},
     py_modules=['pcs']
     )


### PR DESCRIPTION
related to "Use corosync.conf parser structure in cluster setup" commit.

(+ remove trailing whitespace)

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>