### PR TITLE
Fix pcs stonith update traceback

### DIFF
--- a/pcs/stonith.py
+++ b/pcs/stonith.py
@@ -36,8 +36,12 @@ def stonith_cmd(argv):
         )
         resource.resource_create(stn_id, stn_type, st_values, op_values, meta_values)
     elif (sub_cmd == "update"):
-        stn_id = argv.pop(0)
-        resource.resource_update(stn_id,argv)
+        if len(argv) > 1:
+            stn_id = argv.pop(0)
+            resource.resource_update(stn_id,argv)
+        else:
+            usage.stonith(["update"])
+            sys.exit(1)
     elif (sub_cmd == "delete"):
         if len(argv) == 1:
             stn_id = argv.pop(0)


### PR DESCRIPTION
When we try `pcs stonith update`, despite this being incorrect syntax since it lacks the parameters for the stonith update, it produces a calltrace, not an error or usage help:

```
Traceback (most recent call last):
  File "/usr/sbin/pcs", line 219, in <module>
    main(sys.argv[1:])
  File "/usr/sbin/pcs", line 159, in main
    cmd_map[command](argv)
  File "/usr/lib/python2.7/site-packages/pcs/stonith.py", line 39, in stonith_cmd
    stn_id = argv.pop(0)
IndexError: pop from empty list
```

The calltrace is fixed by checking the number of arguments in stonith.py, wherein if there is anything less than the stonith_id it prints usage.