### PR TITLE
Fix for local systemd resources (issue #71)

### DIFF
--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -1352,7 +1352,7 @@ def is_valid_resource(resource, caseInsensitiveCheck=False):
     elif resource.startswith("systemd:"):
         resource_split = resource.split(":",2)
         systemd_ra = resource_split[1]
-        if os.path.isfile("/usr/lib/systemd/system/" + systemd_ra + ".service"):
+        if os.path.isfile("/etc/systemd/system/" + systemd_ra + ".service") or os.path.isfile("/usr/lib/systemd/system/" + systemd_ra + ".service"):
             return True
         else:
             return False


### PR DESCRIPTION
Added check /etc/systemd/system for local services in is_valid_resource

Stops  is_valid_resource returning False for local resources.