### PR TITLE
Support for using login functions in AJAX

### DIFF
--- a/pcsd/pcsd.rb
+++ b/pcsd/pcsd.rb
@@ -369,7 +369,19 @@ if not DISABLE_GUI
 
   get '/logout' do
     session.destroy
-    redirect '/login'
+    if is_ajax?
+      halt [200, session.id]
+    else
+      redirect '/login'
+    end
+  end
+
+  get '/login-status' do
+    if PCSAuth.isLoggedIn(session)
+      halt [200, session.id]
+    else
+      halt [401, '{"notauthorized":"true"}']
+    end
   end
 
   post '/login' do


### PR DESCRIPTION
This commit fixes two following problems:

* Successful /logout redirects you to /login what is not needed for AJAX calls.
* Endpoint where you can check that your session cookie is valid did not exist, now
  it is possible to use /login-status